### PR TITLE
Better formatting of multiallelic variants for BSVI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Takes output VCF of mutect2, splits multiallelic variants into individual
 biallelic records using [bcftools norm][bcftools-url], then modifies genotype
 entries to `0/1`.
 
-n.b. this ONLY changes the genotype field in the sample info, this does NOT modify any of the other allele specific fields (i.e. AD) which will retain entires from all refs and therefore should not be used.
+This should correctly split all multi allelic records into biallelic ones, with the
+alt specific records split out to the appropriate new record.
 
 To add as part of DNAnexus workflow this should be used with the Swiss Army
 Knife app (v.4.1.1). 
@@ -34,6 +35,7 @@ To run with Swiss Army Knife app:
     - python_packages.tar.gz (contains: pandas, numpy, & pytz)
     - mutect2_vcf_2_BSVI_v*_.py
     - swiss_army_cmd_line_v*_.sh
+    - reference fasta file
     - mutect2 VCF
 
 - CMD to run: `sh swiss_army_cmd_line_v*.sh`

--- a/bin/mutect2_vcf_2_BSVI_v1.1.1.py
+++ b/bin/mutect2_vcf_2_BSVI_v1.1.1.py
@@ -37,8 +37,9 @@ def bcf_norm(ref_fasta, input_vcf):
 
     # call bcftools to normalise multiallelic sites
     process = subprocess.Popen((
-        f"zcat {input_vcf} | sed 's/AD,Number=./AD,Number=R/g' | bcftools "
-        f"norm -f {ref_fasta} -m -any"
+        f"zcat {input_vcf} | sed 's/AD,Number=./AD,Number=R/g' | "
+        "sed 's/RPA,Number=./RPA,Number=R/g' | "
+        f"bcftools norm -f {ref_fasta} -m -any"
     ), shell=True, stdout=subprocess.PIPE)
 
     vcf_data = io.StringIO()

--- a/bin/mutect2_vcf_2_BSVI_v1.1.1.py
+++ b/bin/mutect2_vcf_2_BSVI_v1.1.1.py
@@ -39,7 +39,7 @@ def bcf_norm(ref_fasta, input_vcf):
     process = subprocess.Popen((
         f"zcat {input_vcf} | sed 's/AD,Number=./AD,Number=R/g' | "
         "sed 's/RPA,Number=./RPA,Number=R/g' | "
-        f"bcftools norm -f {ref_fasta} -m -any"
+        f"bcftools norm -f {ref_fasta} -m -both"
     ), shell=True, stdout=subprocess.PIPE)
 
     vcf_data = io.StringIO()

--- a/bin/mutect2_vcf_2_BSVI_v1.1.1.py
+++ b/bin/mutect2_vcf_2_BSVI_v1.1.1.py
@@ -5,6 +5,10 @@ the genotype fields splitting from 0/0/1/0 -> 0/1 for BSVI to handle.
 
 Requires bgzip & bcftools be installed and on path.
 
+Inputs:
+    - reference fasta file - required by bcftools norm
+    - input VCF to be modified
+
 Jethro Rainford
 210311
 """
@@ -17,11 +21,12 @@ import sys
 import pandas as pd
 
 
-def bcf_norm(input_vcf):
+def bcf_norm(ref_fasta, input_vcf):
     """
     Normalise multiallelic records using bcftools norm
 
     Args:
+        - ref_fasta (file): reference fasta file to use for bcftools norm
         - input_vcf (file): vcf file passed at cmd line
 
     Returns:
@@ -31,9 +36,10 @@ def bcf_norm(input_vcf):
     print("Calling bcftools")
 
     # call bcftools to normalise multiallelic sites
-    process = subprocess.Popen(
-        f'bcftools norm -m -both {input_vcf}', shell=True, stdout=subprocess.PIPE
-    )
+    process = subprocess.Popen((
+        f"zcat {input_vcf} | sed 's/AD,Number=./AD,Number=R/g' | bcftools "
+        f"norm -f {ref_fasta} -m -any"
+    ), shell=True, stdout=subprocess.PIPE)
 
     vcf_data = io.StringIO()
 
@@ -93,14 +99,16 @@ def write_file(input_vcf, vcf_header, vcf_df):
     # set name for output vcf from input
     """
     Output vcf name comments:
-        - Output vcf name shortened to keep only meaningful characters; removing ngr_ prefix and markdup_recalibrated 
-        - Add _ms suffix to denote that vcf has multiallelic variants split to separate lines
-        e.g.Input vcf: ngr_1701389_S77_L007_markdup_recalibrated_tnhaplotyper2.vcf.gz 
-        Output vcf: 1701389_S77_L007_tnhaplotyper2_ms.vcf.gz
+        - Output vcf name shortened to keep only meaningful characters
+        - Removing ngr_ prefix and markdup_recalibrated 
+        - Add _ms suffix to denote that vcf has multiallelic variants
+          split to separate lines e.g. 
+          Input vcf: ngr_1701389_S77_markdup_recalibrated_tnhaplotyper2.vcf.gz 
+          Output vcf: 1701389_S77_tnhaplotyper2_ms.vcf.gz
     """
     
-    fname = str(Path(input_vcf).name).replace(
-        '.vcf', '_ms.vcf').rstrip('.gz').replace('ngr_', '').replace('_markdup_recalibrated', '')
+    fname = str(Path(input_vcf).name).replace('.vcf', '_ms.vcf').rstrip(
+        '.gz').replace('ngr_', '').replace('_markdup_recalibrated', '')
 
     print(f'Writing to outfile: {fname}.gz')
 
@@ -121,9 +129,17 @@ if __name__ == "__main__":
     # check bcftools is installed and on path
     assert which('bcftools'), 'bcftools is not installed / on path'
 
-    # check only one vcf passed
-    assert len(sys.argv) == 2, 'Incorrect no. VCFs passed, requires one.'
+    # check only reference fasta and one vcf passed
+    assert len(sys.argv) == 3, 'Incorrect no. VCFs passed, requires one.'
 
-    input_vcf = sys.argv[1]
-    vcf_header, vcf_df = bcf_norm(input_vcf)
+    # check reference fasta and vcf are passed correctly
+    assert '.fa' in sys.argv[1] and '.vcf' in sys.argv[2], (
+        'Files passed incorrectly, it should be:'
+        ' python3 mutect2_vcf_2_bsvi.py reference_fasta input_vcf'
+    )
+
+    ref_fasta = sys.argv[1]
+    input_vcf = sys.argv[2]
+
+    vcf_header, vcf_df = bcf_norm(ref_fasta, input_vcf)
     write_file(input_vcf, vcf_header, vcf_df)

--- a/bin/mutect2_vcf_2_BSVI_v1.1.1.py
+++ b/bin/mutect2_vcf_2_BSVI_v1.1.1.py
@@ -37,8 +37,9 @@ def bcf_norm(ref_fasta, input_vcf):
 
     # call bcftools to normalise multiallelic sites
     process = subprocess.Popen((
-        f"zcat {input_vcf} | sed 's/AD,Number=./AD,Number=R/g' | "
-        "sed 's/RPA,Number=./RPA,Number=R/g' | "
+        f"zcat {input_vcf} | "
+        "sed 's/FORMAT=<ID=AD,Number=./FORMAT=<ID=AD,Number=R/g' | "
+        "sed 's/INFO=<ID=RPA,Number=./INFO=<ID=RPA,Number=R/g' | "
         f"bcftools norm -f {ref_fasta} -m -any"
     ), shell=True, stdout=subprocess.PIPE)
 

--- a/bin/swiss_army_cmd_line_v1.1.1.sh
+++ b/bin/swiss_army_cmd_line_v1.1.1.sh
@@ -3,7 +3,9 @@
 # Bash command to call Python script that normalises multiallelic variants in VCF
 # for importing in to BSVI
 
-# Inputs python_packages.tar.gz, mutect2_vcf_2_BSVI.py script and a VCF output from mutect2
+# Inputs python_packages.tar.gz, mutect2_vcf_2_BSVI.py script, reference fasta file
+# and a VCF output from mutect2
+
 # Output: modified VCF with normalised multiallelic variants
 
 set -exo
@@ -17,9 +19,10 @@ pip3 install pytz-*.whl numpy-*.whl pandas-*.whl
 # remove installation packages so they don't get uploaded
 rm -f *.whl
 
+ref=$(find . -name "*.fa.gz")
 vcf=$(find . -name "*.vcf*")
 
 # call Python script to normalise and generate new VCF
-python3 mutect2_vcf_2_BSVI_v*.py $vcf
+python3 mutect2_vcf_2_BSVI_v*.py $ref $vcf
 
 echo "Done"


### PR DESCRIPTION
- added some extra cutting up with `sed` to fully split multi allelic records to individual lines, should now allow bsvi to correctly calculate VAF for each alt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/mutect2_vcf_2_bsvi/10)
<!-- Reviewable:end -->
